### PR TITLE
정상 발화 특성 기준값 함수 추가

### DIFF
--- a/intensity.py
+++ b/intensity.py
@@ -10,8 +10,13 @@ import soundfile as sf
 import speech_recognition as sr
 
 
-def get_normal_intensity(*args) -> dict:
-    # 20대 한국인 남녀의 정상 발화 강도 기준값을 반환합니다.
+def get_normal_intensity() -> dict:
+    """
+    20대 한국인 남녀의 정상 발성 크기 기준값을 반환합니다.
+
+    Returns:
+        dict: 남성 및 여성의 평균(mean)과 표준편차(stddev)를 포함한 딕셔너리
+    """
     return {
         "male_20": {
             "mean": 70.0,

--- a/speechrate.py
+++ b/speechrate.py
@@ -5,13 +5,10 @@ from os import PathLike
 import whisper
 
 
-def get_normal_speechrate(*args) -> dict:
+def get_normal_speechrate() -> dict:
     """
     20대 한국인 남녀의 정상 발화 속도(Speech Rate) 기준값을 반환합니다.
-    
-    *args는 수치 계산에 필요한 파라미터입니다.
-    정상 수치가 고정값(상수, pre-calculated)인 경우 없어도 무방합니다.
-    
+
     Returns:
         dict: 남성 및 여성의 평균(mean)과 표준편차(stddev)를 포함한 딕셔너리
     """


### PR DESCRIPTION
# 정상 발화 특성 기준값 리턴 함수 추가됨. 
1. **`get_normal_intensity()`** (`intensity.py`)
   - 20대 한국인 남녀의 정상 발화 강도(Intensity) 기준값을 반환합니다.
   - 남성: 평균 70.0 dB, 표준편차 6.0 dB
   - 여성: 평균 68.0 dB, 표준편차 6.0 dB

2. **`get_normal_speechrate()`** (`speechrate.py`)
   - 20대 한국인 남녀의 정상 발화 속도(Speech Rate) 기준값을 반환합니다.
   - 남성: 평균 5.8 SPS, 표준편차 0.8 SPS
   - 여성: 평균 5.6 SPS, 표준편차 0.8 SPS
   
- 반환 형식: `{"male_20": {"mean": float, "stddev": float}, "female_20": {"mean": float, "stddev": float}}`